### PR TITLE
Make Godzippa work with latest Cocoapods

### DIFF
--- a/Godzippa/NSData+Godzippa.h
+++ b/Godzippa/NSData+Godzippa.h
@@ -22,8 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <zlib.h>
-
 /**
  Godzippa provides a category on `NSData` to inflate and deflate data using gzip compression.
  */

--- a/Godzippa/NSData+Godzippa.m
+++ b/Godzippa/NSData+Godzippa.m
@@ -22,6 +22,8 @@
 
 #import "NSData+Godzippa.h"
 
+#import <zlib.h>
+
 static const int kGodzippaChunkSize = 1024;
 static const int kGodzippaDefaultMemoryLevel = 8;
 static const int kGodzippaDefaultWindowBits = 15;

--- a/Godzippa/NSFileManager+Godzippa.h
+++ b/Godzippa/NSFileManager+Godzippa.h
@@ -22,8 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <zlib.h>
-
 /**
  Godzippa provides a category on `NSFileManager` to inflate and deflate files using gzip compression.
  */

--- a/Godzippa/NSFileManager+Godzippa.m
+++ b/Godzippa/NSFileManager+Godzippa.m
@@ -22,6 +22,8 @@
 
 #import "NSFileManager+Godzippa.h"
 
+#import <zlib.h>
+
 static const int kGodzippaChunkSize = 4096;
 
 @implementation NSFileManager (Godzippa)


### PR DESCRIPTION
Trying to use Godzippa with the latest Cocoapods which builds a framework fails.

This is because of the zlib import in the header files:

```
include of non-modular header inside framework module
```

Moving the import inside the implementation files seems to fix the issue and the framework and module map is generated automatically for the old podspec.