### PR TITLE
Add nullability annotations to categories

### DIFF
--- a/Example/Godzippa Example.xcodeproj/project.pbxproj
+++ b/Example/Godzippa Example.xcodeproj/project.pbxproj
@@ -33,10 +33,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4320A86D1BB2048300AE91E2 /* GodzippaDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GodzippaDefines.h; sourceTree = "<group>"; };
 		5772CA851A0023E900C9F54F /* NSFileManager+Godzippa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+Godzippa.h"; sourceTree = "<group>"; };
 		5772CA861A0023E900C9F54F /* NSFileManager+Godzippa.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+Godzippa.m"; sourceTree = "<group>"; };
 		5772CA871A0023E900C9F54F /* Godzippa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Godzippa.h; sourceTree = "<group>"; };
-		E2651A82173CC6370091504C /* Godzippa Test.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Godzippa Test.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2651A82173CC6370091504C /* Godzippa Test.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Godzippa Test.octest"; path = "Godzippa Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2651A85173CC6370091504C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		E2651A88173CC6370091504C /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		E2651A89173CC6370091504C /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -169,6 +170,7 @@
 				5772CA851A0023E900C9F54F /* NSFileManager+Godzippa.h */,
 				5772CA861A0023E900C9F54F /* NSFileManager+Godzippa.m */,
 				5772CA871A0023E900C9F54F /* Godzippa.h */,
+				4320A86D1BB2048300AE91E2 /* GodzippaDefines.h */,
 			);
 			name = Godzippa;
 			path = ../Godzippa;

--- a/Godzippa.xcworkspace/contents.xcworkspacedata
+++ b/Godzippa.xcworkspace/contents.xcworkspacedata
@@ -19,6 +19,9 @@
       <FileRef
          location = "group:Godzippa.h">
       </FileRef>
+      <FileRef
+         location = "group:GodzippaDefines.h">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:Example/Godzippa Example.xcodeproj">

--- a/Godzippa/GodzippaDefines.h
+++ b/Godzippa/GodzippaDefines.h
@@ -1,0 +1,9 @@
+#if __has_feature(nullability)
+    #define __GODZIPPA_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
+    #define __GODZIPPA_ASSUME_NONNULL_END   NS_ASSUME_NONNULL_END
+    #define __GODZIPPA_NULLABLE __nullable
+#else
+    #define __GODZIPPA_ASSUME_NONNULL_BEGIN
+    #define __GODZIPPA_ASSUME_NONNULL_END
+    #define __GODZIPPA_NULLABLE
+#endif

--- a/Godzippa/NSData+Godzippa.h
+++ b/Godzippa/NSData+Godzippa.h
@@ -24,6 +24,10 @@
 
 #import <zlib.h>
 
+#import "GodzippaDefines.h"
+
+__GODZIPPA_ASSUME_NONNULL_BEGIN
+
 /**
  Godzippa provides a category on `NSData` to inflate and deflate data using gzip compression.
  */
@@ -40,7 +44,7 @@
 
  @return The compressed data.
  */
-- (NSData *)dataByGZipCompressingWithError:(NSError * __autoreleasing *)error;
+- (NSData * __GODZIPPA_NULLABLE)dataByGZipCompressingWithError:(NSError * __autoreleasing *)error;
 
 /**
  Returns the deflated of the receiver using gzip compression with the specified zlib values for compression level, window size, internal memory allocation, and strategy.
@@ -53,11 +57,11 @@
 
  @return The compressed data.
  */
-- (NSData *)dataByGZipCompressingAtLevel:(int)level
-                              windowSize:(int)windowBits
-                             memoryLevel:(int)memLevel
-                                strategy:(int)strategy
-                                   error:(NSError * __autoreleasing *)error;
+- (NSData * __GODZIPPA_NULLABLE)dataByGZipCompressingAtLevel:(int)level
+                                                  windowSize:(int)windowBits
+                                                 memoryLevel:(int)memLevel
+                                                    strategy:(int)strategy
+                                                       error:(NSError * __autoreleasing *)error;
 
 ///--------------------
 /// @name Decompressing
@@ -70,7 +74,7 @@
 
  @return The decompressed data.
  */
-- (NSData *)dataByGZipDecompressingDataWithError:(NSError * __autoreleasing *)error;
+- (NSData * __GODZIPPA_NULLABLE)dataByGZipDecompressingDataWithError:(NSError * __autoreleasing *)error;
 
 /**
  Returns the inflated of the receiver using gzip compression with the specified zlib value for window size.
@@ -80,8 +84,8 @@
 
  @return The decompressed data.
  */
-- (NSData *)dataByGZipDecompressingDataWithWindowSize:(int)windowBits
-                                                error:(NSError * __autoreleasing *)error;
+- (NSData * __GODZIPPA_NULLABLE)dataByGZipDecompressingDataWithWindowSize:(int)windowBits
+                                                                    error:(NSError * __autoreleasing *)error;
 
 @end
 
@@ -96,3 +100,5 @@
  Godzippa errors. Error codes for `GodzippaZlibErrorDomain` correspond to status codes from zlib.
  */
 extern NSString * const GodzippaZlibErrorDomain;
+
+__GODZIPPA_ASSUME_NONNULL_END

--- a/Godzippa/NSFileManager+Godzippa.h
+++ b/Godzippa/NSFileManager+Godzippa.h
@@ -24,6 +24,10 @@
 
 #import <zlib.h>
 
+#import "GodzippaDefines.h"
+
+__GODZIPPA_ASSUME_NONNULL_BEGIN
+
 /**
  Godzippa provides a category on `NSFileManager` to inflate and deflate files using gzip compression.
  */
@@ -76,3 +80,5 @@
                      error:(NSError * __autoreleasing *)error;
 
 @end
+
+__GODZIPPA_ASSUME_NONNULL_END


### PR DESCRIPTION
I added nullability annotations to `NSData+Godzippa.h` and `NSFileManager+Godzippa.h`, to make the library more usable in Swift. They're guarded behind `__has_feature`, so they should work in old Xcodes too, if desired.

Apologies for the unintentional `.octest` change in the `pbxproj` diff, I didn't catch Xcode making that one.
