### PR TITLE
Add xcodeproj for Godzippa, with targets & shared schemes for OS X, iOS, and watchOS

### DIFF
--- a/Godzippa.xcodeproj/project.pbxproj
+++ b/Godzippa.xcodeproj/project.pbxproj
@@ -19,6 +19,12 @@
 		4320A8441BB2002C00AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8451BB2002C00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8461BB2002C00AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A84F1BB2030C00AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A8501BB2030C00AE91E2 /* NSData+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A8521BB2030C00AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
+		4320A8541BB2030C00AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8551BB2030C00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8561BB2030C00AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +37,7 @@
 		4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+Godzippa.m"; sourceTree = "<group>"; };
 		4320A83B1BB1FF9300AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		4320A84B1BB2002C00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4320A85B1BB2030C00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -47,6 +54,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4320A8421BB2002C00AE91E2 /* libz.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A8511BB2030C00AE91E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8521BB2030C00AE91E2 /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,6 +82,7 @@
 			children = (
 				4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */,
 				4320A84B1BB2002C00AE91E2 /* Godzippa.framework */,
+				4320A85B1BB2030C00AE91E2 /* Godzippa.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -104,6 +120,16 @@
 				4320A8441BB2002C00AE91E2 /* NSFileManager+Godzippa.h in Headers */,
 				4320A8451BB2002C00AE91E2 /* Godzippa.h in Headers */,
 				4320A8461BB2002C00AE91E2 /* NSData+Godzippa.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A8531BB2030C00AE91E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8541BB2030C00AE91E2 /* NSFileManager+Godzippa.h in Headers */,
+				4320A8551BB2030C00AE91E2 /* Godzippa.h in Headers */,
+				4320A8561BB2030C00AE91E2 /* NSData+Godzippa.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,6 +172,24 @@
 			productReference = 4320A84B1BB2002C00AE91E2 /* Godzippa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		4320A84D1BB2030C00AE91E2 /* Godzippa-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4320A8581BB2030C00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-watchOS" */;
+			buildPhases = (
+				4320A84E1BB2030C00AE91E2 /* Sources */,
+				4320A8511BB2030C00AE91E2 /* Frameworks */,
+				4320A8531BB2030C00AE91E2 /* Headers */,
+				4320A8571BB2030C00AE91E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Godzippa-watchOS";
+			productName = Godzippa;
+			productReference = 4320A85B1BB2030C00AE91E2 /* Godzippa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -173,6 +217,7 @@
 			targets = (
 				4320A8271BB1FEDB00AE91E2 /* Godzippa-OSX */,
 				4320A83D1BB2002C00AE91E2 /* Godzippa-iOS */,
+				4320A84D1BB2030C00AE91E2 /* Godzippa-watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -186,6 +231,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4320A8471BB2002C00AE91E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A8571BB2030C00AE91E2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -210,6 +262,15 @@
 			files = (
 				4320A83F1BB2002C00AE91E2 /* NSFileManager+Godzippa.m in Sources */,
 				4320A8401BB2002C00AE91E2 /* NSData+Godzippa.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A84E1BB2030C00AE91E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A84F1BB2030C00AE91E2 /* NSFileManager+Godzippa.m in Sources */,
+				4320A8501BB2030C00AE91E2 /* NSData+Godzippa.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -444,6 +505,115 @@
 			};
 			name = Release;
 		};
+		4320A8591BB2030C00AE91E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4320A85A1BB2030C00AE91E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -469,6 +639,15 @@
 			buildConfigurations = (
 				4320A8491BB2002C00AE91E2 /* Debug */,
 				4320A84A1BB2002C00AE91E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4320A8581BB2030C00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4320A8591BB2030C00AE91E2 /* Debug */,
+				4320A85A1BB2030C00AE91E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Godzippa.xcodeproj/project.pbxproj
+++ b/Godzippa.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		4320A8381BB1FF4100AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8391BB1FF4100AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
 		4320A83C1BB1FF9300AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
+		4320A83F1BB2002C00AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A8401BB2002C00AE91E2 /* NSData+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A8421BB2002C00AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
+		4320A8441BB2002C00AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8451BB2002C00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8461BB2002C00AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +30,7 @@
 		4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+Godzippa.h"; sourceTree = "<group>"; };
 		4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+Godzippa.m"; sourceTree = "<group>"; };
 		4320A83B1BB1FF9300AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		4320A84B1BB2002C00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -32,6 +39,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4320A83C1BB1FF9300AE91E2 /* libz.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A8411BB2002C00AE91E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8421BB2002C00AE91E2 /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -51,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */,
+				4320A84B1BB2002C00AE91E2 /* Godzippa.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -81,6 +97,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4320A8431BB2002C00AE91E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8441BB2002C00AE91E2 /* NSFileManager+Godzippa.h in Headers */,
+				4320A8451BB2002C00AE91E2 /* Godzippa.h in Headers */,
+				4320A8461BB2002C00AE91E2 /* NSData+Godzippa.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -100,6 +126,24 @@
 			name = "Godzippa-OSX";
 			productName = Godzippa;
 			productReference = 4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4320A83D1BB2002C00AE91E2 /* Godzippa-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4320A8481BB2002C00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-iOS" */;
+			buildPhases = (
+				4320A83E1BB2002C00AE91E2 /* Sources */,
+				4320A8411BB2002C00AE91E2 /* Frameworks */,
+				4320A8431BB2002C00AE91E2 /* Headers */,
+				4320A8471BB2002C00AE91E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Godzippa-iOS";
+			productName = Godzippa;
+			productReference = 4320A84B1BB2002C00AE91E2 /* Godzippa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -128,12 +172,20 @@
 			projectRoot = "";
 			targets = (
 				4320A8271BB1FEDB00AE91E2 /* Godzippa-OSX */,
+				4320A83D1BB2002C00AE91E2 /* Godzippa-iOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4320A8261BB1FEDB00AE91E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A8471BB2002C00AE91E2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -149,6 +201,15 @@
 			files = (
 				4320A8391BB1FF4100AE91E2 /* NSFileManager+Godzippa.m in Sources */,
 				4320A8371BB1FF4100AE91E2 /* NSData+Godzippa.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4320A83E1BB2002C00AE91E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A83F1BB2002C00AE91E2 /* NSFileManager+Godzippa.m in Sources */,
+				4320A8401BB2002C00AE91E2 /* NSData+Godzippa.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -274,6 +335,115 @@
 			};
 			name = Release;
 		};
+		4320A8491BB2002C00AE91E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4320A84A1BB2002C00AE91E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -293,6 +463,15 @@
 				4320A82F1BB1FEDB00AE91E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+		};
+		4320A8481BB2002C00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4320A8491BB2002C00AE91E2 /* Debug */,
+				4320A84A1BB2002C00AE91E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Godzippa.xcodeproj/project.pbxproj
+++ b/Godzippa.xcodeproj/project.pbxproj
@@ -1,0 +1,67 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXGroup section */
+		4320A81C1BB1FE2D00AE91E2 = {
+			isa = PBXGroup;
+			children = (
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		4320A81D1BB1FE2D00AE91E2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0700;
+			};
+			buildConfigurationList = 4320A8201BB1FE2D00AE91E2 /* Build configuration list for PBXProject "Godzippa" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4320A81C1BB1FE2D00AE91E2;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+			);
+		};
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+		4320A8211BB1FE2D00AE91E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		4320A8221BB1FE2D00AE91E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4320A8201BB1FE2D00AE91E2 /* Build configuration list for PBXProject "Godzippa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4320A8211BB1FE2D00AE91E2 /* Debug */,
+				4320A8221BB1FE2D00AE91E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4320A81D1BB1FE2D00AE91E2 /* Project object */;
+}

--- a/Godzippa.xcodeproj/project.pbxproj
+++ b/Godzippa.xcodeproj/project.pbxproj
@@ -15,16 +15,16 @@
 		4320A83C1BB1FF9300AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
 		4320A83F1BB2002C00AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
 		4320A8401BB2002C00AE91E2 /* NSData+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
-		4320A8421BB2002C00AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
 		4320A8441BB2002C00AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8451BB2002C00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8461BB2002C00AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A84F1BB2030C00AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
 		4320A8501BB2030C00AE91E2 /* NSData+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
-		4320A8521BB2030C00AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
 		4320A8541BB2030C00AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8551BB2030C00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4320A8561BB2030C00AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8771BB207D100AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A8761BB207D100AE91E2 /* libz.tbd */; };
+		4320A8791BB207DC00AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A8781BB207DC00AE91E2 /* libz.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +38,8 @@
 		4320A83B1BB1FF9300AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		4320A84B1BB2002C00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4320A85B1BB2030C00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4320A8761BB207D100AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.0.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
+		4320A8781BB207DC00AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4320A8421BB2002C00AE91E2 /* libz.tbd in Frameworks */,
+				4320A8791BB207DC00AE91E2 /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4320A8521BB2030C00AE91E2 /* libz.tbd in Frameworks */,
+				4320A8771BB207D100AE91E2 /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,9 +73,9 @@
 		4320A81C1BB1FE2D00AE91E2 = {
 			isa = PBXGroup;
 			children = (
-				4320A83B1BB1FF9300AE91E2 /* libz.tbd */,
 				4320A82A1BB1FEDB00AE91E2 /* Godzippa */,
 				4320A8291BB1FEDB00AE91E2 /* Products */,
+				4320A87A1BB207E900AE91E2 /* Libraries */,
 			);
 			sourceTree = "<group>";
 		};
@@ -98,6 +100,16 @@
 				4320A82D1BB1FEDB00AE91E2 /* Info.plist */,
 			);
 			path = Godzippa;
+			sourceTree = "<group>";
+		};
+		4320A87A1BB207E900AE91E2 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				4320A83B1BB1FF9300AE91E2 /* libz.tbd */,
+				4320A8781BB207DC00AE91E2 /* libz.tbd */,
+				4320A8761BB207D100AE91E2 /* libz.tbd */,
+			);
+			name = Libraries;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -633,6 +645,7 @@
 				4320A82F1BB1FEDB00AE91E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4320A8481BB2002C00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-iOS" */ = {
 			isa = XCConfigurationList;

--- a/Godzippa.xcodeproj/project.pbxproj
+++ b/Godzippa.xcodeproj/project.pbxproj
@@ -6,20 +6,114 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		4320A82C1BB1FEDB00AE91E2 /* Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8361BB1FF4100AE91E2 /* NSData+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8371BB1FF4100AE91E2 /* NSData+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A8381BB1FF4100AE91E2 /* NSFileManager+Godzippa.h in Headers */ = {isa = PBXBuildFile; fileRef = 4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4320A8391BB1FF4100AE91E2 /* NSFileManager+Godzippa.m in Sources */ = {isa = PBXBuildFile; fileRef = 4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */; settings = {ASSET_TAGS = (); }; };
+		4320A83C1BB1FF9300AE91E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4320A83B1BB1FF9300AE91E2 /* libz.tbd */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Godzippa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Godzippa.h; sourceTree = "<group>"; };
+		4320A82D1BB1FEDB00AE91E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Godzippa.h"; sourceTree = "<group>"; };
+		4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Godzippa.m"; sourceTree = "<group>"; };
+		4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+Godzippa.h"; sourceTree = "<group>"; };
+		4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+Godzippa.m"; sourceTree = "<group>"; };
+		4320A83B1BB1FF9300AE91E2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4320A8241BB1FEDB00AE91E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A83C1BB1FF9300AE91E2 /* libz.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
 /* Begin PBXGroup section */
 		4320A81C1BB1FE2D00AE91E2 = {
 			isa = PBXGroup;
 			children = (
+				4320A83B1BB1FF9300AE91E2 /* libz.tbd */,
+				4320A82A1BB1FEDB00AE91E2 /* Godzippa */,
+				4320A8291BB1FEDB00AE91E2 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
+		4320A8291BB1FEDB00AE91E2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4320A82A1BB1FEDB00AE91E2 /* Godzippa */ = {
+			isa = PBXGroup;
+			children = (
+				4320A82B1BB1FEDB00AE91E2 /* Godzippa.h */,
+				4320A8311BB1FF4100AE91E2 /* NSData+Godzippa.h */,
+				4320A8321BB1FF4100AE91E2 /* NSData+Godzippa.m */,
+				4320A8331BB1FF4100AE91E2 /* NSFileManager+Godzippa.h */,
+				4320A8341BB1FF4100AE91E2 /* NSFileManager+Godzippa.m */,
+				4320A82D1BB1FEDB00AE91E2 /* Info.plist */,
+			);
+			path = Godzippa;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4320A8251BB1FEDB00AE91E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8381BB1FF4100AE91E2 /* NSFileManager+Godzippa.h in Headers */,
+				4320A82C1BB1FEDB00AE91E2 /* Godzippa.h in Headers */,
+				4320A8361BB1FF4100AE91E2 /* NSData+Godzippa.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4320A8271BB1FEDB00AE91E2 /* Godzippa-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4320A8301BB1FEDB00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-OSX" */;
+			buildPhases = (
+				4320A8231BB1FEDB00AE91E2 /* Sources */,
+				4320A8241BB1FEDB00AE91E2 /* Frameworks */,
+				4320A8251BB1FEDB00AE91E2 /* Headers */,
+				4320A8261BB1FEDB00AE91E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Godzippa-OSX";
+			productName = Godzippa;
+			productReference = 4320A8281BB1FEDB00AE91E2 /* Godzippa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		4320A81D1BB1FE2D00AE91E2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					4320A8271BB1FEDB00AE91E2 = {
+						CreatedOnToolsVersion = 7.0;
+					};
+				};
 			};
 			buildConfigurationList = 4320A8201BB1FE2D00AE91E2 /* Build configuration list for PBXProject "Godzippa" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -29,12 +123,36 @@
 				en,
 			);
 			mainGroup = 4320A81C1BB1FE2D00AE91E2;
+			productRefGroup = 4320A8291BB1FEDB00AE91E2 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				4320A8271BB1FEDB00AE91E2 /* Godzippa-OSX */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4320A8261BB1FEDB00AE91E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4320A8231BB1FEDB00AE91E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4320A8391BB1FF4100AE91E2 /* NSFileManager+Godzippa.m in Sources */,
+				4320A8371BB1FF4100AE91E2 /* NSData+Godzippa.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		4320A8211BB1FE2D00AE91E2 /* Debug */ = {
@@ -49,6 +167,113 @@
 			};
 			name = Release;
 		};
+		4320A82E1BB1FEDB00AE91E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4320A82F1BB1FEDB00AE91E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Godzippa/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.godzippa.Godzippa;
+				PRODUCT_NAME = Godzippa;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -60,6 +285,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		4320A8301BB1FEDB00AE91E2 /* Build configuration list for PBXNativeTarget "Godzippa-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4320A82E1BB1FEDB00AE91E2 /* Debug */,
+				4320A82F1BB1FEDB00AE91E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-OSX.xcscheme
+++ b/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4320A8271BB1FEDB00AE91E2"
+               BuildableName = "Godzippa.framework"
+               BlueprintName = "Godzippa-OSX"
+               ReferencedContainer = "container:Godzippa.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A8271BB1FEDB00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-OSX"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A8271BB1FEDB00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-OSX"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-iOS.xcscheme
+++ b/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4320A83D1BB2002C00AE91E2"
+               BuildableName = "Godzippa.framework"
+               BlueprintName = "Godzippa-iOS"
+               ReferencedContainer = "container:Godzippa.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A83D1BB2002C00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-iOS"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A83D1BB2002C00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-iOS"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-watchOS.xcscheme
+++ b/Godzippa.xcodeproj/xcshareddata/xcschemes/Godzippa-watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4320A84D1BB2030C00AE91E2"
+               BuildableName = "Godzippa.framework"
+               BlueprintName = "Godzippa-watchOS"
+               ReferencedContainer = "container:Godzippa.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A84D1BB2030C00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-watchOS"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4320A84D1BB2030C00AE91E2"
+            BuildableName = "Godzippa.framework"
+            BlueprintName = "Godzippa-watchOS"
+            ReferencedContainer = "container:Godzippa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Godzippa.xcworkspace/contents.xcworkspacedata
+++ b/Godzippa.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <FileRef
+      location = "group:Godzippa.xcodeproj">
+   </FileRef>
    <Group
       location = "group:Godzippa"
       name = "Godzippa">

--- a/Godzippa.xcworkspace/contents.xcworkspacedata
+++ b/Godzippa.xcworkspace/contents.xcworkspacedata
@@ -4,25 +4,6 @@
    <FileRef
       location = "group:Godzippa.xcodeproj">
    </FileRef>
-   <Group
-      location = "group:Godzippa"
-      name = "Godzippa">
-      <FileRef
-         location = "group:NSData+Godzippa.h">
-      </FileRef>
-      <FileRef
-         location = "group:NSData+Godzippa.m">
-      </FileRef>
-      <FileRef
-         location = "group:NSFileManager+Godzippa.h">
-      </FileRef>
-      <FileRef
-         location = "group:NSFileManager+Godzippa.m">
-      </FileRef>
-      <FileRef
-         location = "group:Godzippa.h">
-      </FileRef>
-   </Group>
    <FileRef
       location = "group:Example/Godzippa Example.xcodeproj">
    </FileRef>

--- a/Godzippa/Godzippa.h
+++ b/Godzippa/Godzippa.h
@@ -20,5 +20,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "NSData+Godzippa.h"
-#import "NSFileManager+Godzippa.h"
+#import <Godzippa/NSData+Godzippa.h>
+#import <Godzippa/NSFileManager+Godzippa.h>

--- a/Godzippa/Info.plist
+++ b/Godzippa/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
To use the library with Carthage, I added `Godzippa.xcodeproj`, and shared the schemes for the framework targets.

I also [created a branch](https://github.com/natestedman/Godzippa/tree/project-and-nullability) that resolves the merge conflicts with my other pull request and this one.
